### PR TITLE
Fix mobile layout in action plan final screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
         <h2 class="text-xl font-semibold text-gray-800 mb-4 border-b pb-2">Plano de Ação</h2>
         <div id="action-plan-container" class="space-y-6"></div>
     </div>
-    <div class="mt-8 flex justify-between w-full">
+    <div class="mt-8 flex flex-wrap items-center justify-center gap-4 w-full max-w-screen-sm mx-auto">
         <button data-prev-step="3" class="bg-gray-300 text-gray-800 font-bold py-2 px-6 rounded-lg hover:bg-gray-400">Voltar</button>
         <button id="action-plan-next" class="bg-blue-600 text-white font-bold py-2 px-6 rounded-lg hover:bg-blue-700 shadow-lg">Continuar</button>
     </div>
@@ -160,6 +160,9 @@
             <div id="step-4" class="step">
                  <div class="bg-white p-6 rounded-xl shadow-md w-full">
                      <h2 class="text-xl font-semibold text-gray-800 mb-4 border-b pb-2">Assinaturas</h2>
+                     <div id="action-plan-success" class="mt-4 text-green-600 font-semibold text-center hidden">
+                         Plano de Ação gerado com sucesso! Você pode continuar ou voltar.
+                     </div>
                      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-2">Assinatura do Responsável</label>
@@ -615,6 +618,7 @@ document.getElementById("action-plan-next").addEventListener("click", async () =
     });
     const pdfData = generateActionPlanPDF();
     await saveActionPlan(pdfData);
+    document.getElementById('action-plan-success').classList.remove('hidden');
     navigateToStep(4);
 });
         const generateBtn = document.getElementById('generate-pdf-btn');


### PR DESCRIPTION
## Summary
- keep action plan buttons aligned on mobile using flex-wrap and gap
- show a success message after the action plan PDF is saved

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68681cbadca4832e984db69f105bf252