### PR TITLE
Implement tela inicial e ajustes de consultas

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,14 @@
 
         <main>
         <div id="tab-new" class="tab-content active">
+            <div id="entry-screen" class="flex flex-col items-center justify-center h-screen bg-white rounded-xl shadow-lg p-6 mb-4 text-center">
+              <h1 class="text-2xl font-bold text-gray-800 mb-6">Bem-vindo ao TraktoAudit</h1>
+              <button id="abrirNovaAuditoria" class="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-3 rounded-xl shadow-md">
+                Nova Auditoria
+              </button>
+            </div>
             <!-- Etapa 0: Dados Iniciais -->
-            <div id="step-0" class="step active">
+            <div id="step-0" class="step">
                 <div class="bg-white p-6 rounded-xl shadow-md mb-4">
                     <h2 class="text-xl font-semibold text-gray-800 mb-4 border-b pb-2">Nova Auditoria</h2>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -243,6 +249,8 @@ import { gerarRelatorioPlanoAcao } from './planoAcaoPDF.js';
         let actionPlanData = [];
         let actionPlanPdfData = null;
         let clienteCnpj = "";
+        const entryScreen = document.getElementById("entry-screen");
+        const openAuditBtn = document.getElementById("abrirNovaAuditoria");
         let clienteRazao = "";
         let responsavelNome = "";
         let responsavelCargo = "";
@@ -385,6 +393,10 @@ showRegister.addEventListener("click", () => {
     }
     navigateToStep(2);
   });
+openAuditBtn.addEventListener("click", () => {
+  entryScreen.classList.add("hidden");
+  navigateToStep(0);
+});
         
         let auditAnswers = {};
         let currentStep = 0;
@@ -615,7 +627,7 @@ function populateActionPlan() {
             const ans = document.querySelector(`input[name="${q.id}"]:checked`);
             if (ans && ans.value === "Não Conforme") {
                 const div = document.createElement("div");
-                div.className = "bg-white rounded-xl shadow-md p-6 mb-4";
+                div.className = "bg-white rounded-xl shadow-md p-4 mb-4";
                 div.innerHTML = `
                     <p class="font-medium mb-2">${q.text}</p>
                     <textarea data-q="${q.id}" class="w-full px-3 py-2 border border-gray-300 rounded-lg mb-4" placeholder="Justificativa"></textarea>
@@ -642,7 +654,7 @@ function populateActionPlanFromStored(resps){
         cat.questions.forEach(q=>{
             if(resps[q.id]==='Não Conforme'){
                 const div=document.createElement('div');
-                div.className='bg-white rounded-xl shadow-md p-6 mb-4';
+                div.className='bg-white rounded-xl shadow-md p-4 mb-4';
                 div.innerHTML=`<p class="font-medium mb-2">${q.text}</p><textarea data-q="${q.id}" class="w-full px-3 py-2 border border-gray-300 rounded-lg mb-4" placeholder="Justificativa"></textarea><div class="flex flex-col gap-y-4 px-4 sm:flex-row sm:gap-x-4 sm:px-0"><div><label for="dataInicial-${q.id}" class="block text-sm font-medium text-gray-700 mb-1">Data Inicial</label><input id="dataInicial-${q.id}" type="date" data-start class="w-full rounded-lg border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"></div><div><label for="dataFinal-${q.id}" class="block text-sm font-medium text-gray-700 mb-1">Data Final</label><input id="dataFinal-${q.id}" type="date" data-end class="w-full rounded-lg border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500"></div></div>`;
                 container.appendChild(div);
             }
@@ -675,7 +687,7 @@ async function prepareActionPlanTab(){
             if(docSnap.exists()){
                 const d = docSnap.data();
                 const div=document.createElement('div');
-                div.className='bg-white rounded-xl shadow-md p-6 mb-4';
+                div.className='bg-white rounded-xl shadow-md p-4 mb-4';
                 div.innerHTML=`
                     <p class='font-semibold'>${d.estabelecimento || d.razaoSocial || ''}</p>
                     <p class='text-sm text-gray-500 mb-2'>${d.data ? new Date(d.data).toLocaleDateString('pt-BR') : ''}</p>
@@ -686,7 +698,7 @@ async function prepareActionPlanTab(){
             }
         });
     } catch (error) {
-        console.error('Erro ao consultar Firestore. Verifique se o índice foi criado:', error); // Crie o índice composto no Firestore se este erro persistir
+        console.warn('Erro ao consultar Firestore. Verifique se o índice foi criado:', error); // Você pode criar o índice manualmente com o link mostrado no console
     }
 }
 
@@ -908,7 +920,7 @@ async function loadHistory(){
             if(docSnap.exists()){
                 const d = docSnap.data();
                 const div = document.createElement('div');
-                div.className='bg-white rounded-xl shadow-md p-6 mb-4';
+                div.className='bg-white rounded-xl shadow-md p-4 mb-4';
                 div.innerHTML=`
                     <p class='font-semibold'>${d.estabelecimento || d.razaoSocial || ''}</p>
                     <p class='text-sm text-gray-500'>${d.data ? new Date(d.data).toLocaleDateString('pt-BR') : ''}</p>
@@ -924,7 +936,7 @@ async function loadHistory(){
             }
         });
     } catch (error) {
-        console.error('Erro ao consultar Firestore. Verifique se o índice foi criado:', error); // Crie o índice composto no Firestore se este erro persistir
+        console.warn('Erro ao consultar Firestore. Verifique se o índice foi criado:', error); // Você pode criar o índice manualmente com o link mostrado no console
     }
 }
 


### PR DESCRIPTION
## Summary
- add entry screen before new audit form
- tweak Firestore query error handling
- hide audit form until button click
- style history cards

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6872ddd31d04832e8664cd5b58665e87