### PR TITLE
Fix login background and header layout

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -8,7 +8,7 @@
 </head>
 <body class="bg-white text-gray-800 p-4">
   <header class="flex justify-between items-center mb-6">
-     <img src="https://i.imgur.com/sDGp7Gb.png" crossorigin="anonymous" alt="Logo" class="w-28">
+     <img src="https://traktoaudit.vercel.app/assets/logo-foodops.jpg" alt="Logo" class="w-28">
      <h1 class="text-xl font-bold">Painel Administrativo</h1>
      <button id="logout-btn" class="bg-gray-600 text-white px-3 py-1 rounded">Sair</button>
   </header>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,10 @@
     <style>
         body { font-family: 'Inter', sans-serif; }
         #auth-container {
-            background-image: url('https://i.imgur.com/aTfqWps.jpeg');
+            background-image: url('https://traktoaudit.vercel.app/assets/bg-login.jpg');
             background-size: cover;
             background-position: center;
+            background-repeat: no-repeat;
         }
         .step, .question-container, .non-conformity-section, .photo-preview { display: none; }
         .step.active { display: flex; }
@@ -62,23 +63,18 @@
         </form>
     </div>
 
-    <div id="app-container" class="container mx-auto max-w-4xl p-4 sm:p-6 md:p-8" style="display:none;">
-        
-        <header id="main-header" class="bg-white p-4 sm:p-6 rounded-xl shadow-md mb-8 flex-col sm:flex-row justify-between items-center">
-            <div class="text-center sm:text-left">
-                <h1 class="text-xl sm:text-2xl font-bold text-gray-900">Auditoria Sanitária</h1>
-                <p id="header-subtitle" class="text-gray-600"></p>
-            </div>
-            <div class="mt-4 sm:mt-0">
-                <img id="company-logo-header" src="https://i.imgur.com/sDGp7Gb.png" crossorigin="anonymous" class="w-28" alt="Logo" />
-            </div>
-            <div id="user-info" class="text-sm text-gray-700 text-right"></div>
+    <div id="app-container" class="container mx-auto max-w-4xl p-4 sm:p-6 md:p-8 flex flex-col min-h-screen" style="display:none;">
+
+        <header id="main-header" class="bg-white p-4 sm:p-6 rounded-xl shadow-md mb-8 flex flex-col items-center space-y-2">
+            <img id="company-logo-header" src="https://traktoaudit.vercel.app/assets/logo-foodops.jpg" class="w-40 mx-auto" alt="Logo" />
+            <p id="header-subtitle" class="text-gray-600"></p>
+            <div id="user-info" class="text-sm text-gray-700 text-center"></div>
         </header>
 
-        <nav id="tab-buttons" class="flex flex-col items-center space-y-6 my-8">
-            <button data-tab="tab-new" class="tab-btn w-4/5 bg-blue-600 text-white py-4 rounded-lg shadow">Nova Auditoria</button>
-            <button data-tab="tab-history" class="tab-btn w-4/5 bg-white text-gray-800 py-4 rounded-lg shadow">Histórico</button>
-            <button data-tab="tab-action" class="tab-btn w-4/5 bg-white text-gray-800 py-4 rounded-lg shadow">Plano de Ação</button>
+        <nav id="tab-buttons" class="flex flex-col items-center justify-center flex-grow space-y-6 my-8">
+            <button data-tab="tab-new" class="tab-btn w-4/5 bg-white text-gray-800 py-6 rounded-lg shadow font-semibold">Nova Auditoria</button>
+            <button data-tab="tab-history" class="tab-btn w-4/5 bg-white text-gray-800 py-6 rounded-lg shadow font-semibold">Histórico</button>
+            <button data-tab="tab-action" class="tab-btn w-4/5 bg-white text-gray-800 py-6 rounded-lg shadow font-semibold">Plano de Ação</button>
         </nav>
 
         <main>


### PR DESCRIPTION
## Summary
- use working background image for login screen
- update header with FoodOps logo and centered user info
- style main menu buttons to display as white cards
- update admin header logo link

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68730596987c832ea2095d3825e98466